### PR TITLE
ath79: add support for gl-e750

### DIFF
--- a/target/linux/ath79/dts/qca9531_glinet_gl-e750.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-e750.dts
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	compatible = "glinet,gl-e750", "qca,qca9531";
+	model = "GL.iNet GL-E750";
+
+	aliases {
+		label-mac-device = &eth0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		switch {
+			label = "switch";
+			linux,code = <BTN_0>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_lte_power {
+			gpio-export,name = "lte_power";
+			gpio-export,output = <1>;
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		};
+	 };
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <2>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x10000>;
+			};
+
+			art: partition@50000 {
+				label = "art";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "kernel";
+				reg = <0x60000 0x400000>;
+			};
+
+			partition@460000 {
+				label = "reserved";
+				reg = <0x460000 0xba0000>;
+			};
+		};
+	};
+
+	flash@1 {
+		compatible = "spi-nand";
+		reg = <1>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubi";
+				reg = <0x0 0x8000000>;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+	phy-handle = <&swphy4>;
+};
+
+&eth1 {
+	compatible = "syscon", "simple-mfd";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -122,6 +122,23 @@ define Device/glinet_gl-ar750s-nor
 endef
 TARGET_DEVICES += glinet_gl-ar750s-nor
 
+define Device/glinet_gl-e750
+  SOC := qca9531
+  DEVICE_VENDOR := GL.iNet
+  DEVICE_MODEL := GL-E750
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct kmod-usb2
+  SUPPORTED_DEVICES += gl-e750
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 131072k
+  PAGESIZE := 2048
+  VID_HDR_OFFSET := 2048
+  BLOCKSIZE := 128k
+  IMAGES += factory.img
+  IMAGE/factory.img := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += glinet_gl-e750
+
 # fake rootfs is mandatory, pad-offset 129 equals (2 * uimage_header + 0xff)
 define Device/netgear_ath79_nand
   DEVICE_VENDOR := NETGEAR

--- a/target/linux/ath79/nand/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/nand/base-files/etc/board.d/02_network
@@ -8,7 +8,8 @@ ath79_setup_interfaces()
 	local board="$1"
 
 	case "$board" in
-	aerohive,hiveap-121)
+	aerohive,hiveap-121|\
+	glinet,gl-e750)
 		ucidef_set_interface_lan "eth0"
 		;;
 	domywifi,dw33d)

--- a/target/linux/ath79/nand/base-files/etc/hotplug.d/ieee80211/10-fix-wifi-mac
+++ b/target/linux/ath79/nand/base-files/etc/hotplug.d/ieee80211/10-fix-wifi-mac
@@ -10,6 +10,11 @@ PHYNBR=${DEVPATH##*/phy}
 board=$(board_name)
 
 case $board in
+	glinet,gl-e750)
+		# Set mac address for 5g device
+		[ "$PHYNBR" -eq 0 ] && \
+			macaddr_add $(mtd_get_mac_binary art 0x0) 2 > /sys${DEVPATH}/macaddress
+		;;
 	zyxel,nbg6716)
 		# Set mac address for 2.4g device
 		[ "$PHYNBR" -eq 1 ] && \


### PR DESCRIPTION
The gl-e750 is a portable travel router that gives you safe access to
the internet while traveling.

Specifications:
- SoC: Qualcomm Atheros AR9531 (650MHz)
- RAM: 128 MB DDR2
- Flash: 16 MB SPI NOR (W25Q128FVSG) + 128 MB SPI NAND (GD5F1GQ4UFYIG)
- Ethernet: 10/100: 1xLAN
- Wireless: QCA9531 2.4GHz (bgn) + QCA9887 5GHz (ac)
- USB: 1x USB 2.0 port
- Switch: 1x switch
- Button: 1x reset button
- OLED Screen: 128*64 px

MAC addresses based on vendor firmware:
LAN *:a0 art 0x0
2.4GHz *:a1 art 0x1002
5GHz *:a2 art calculated from art 0x0 + 2

Flash firmware:
Since openwrt's kernel already exceeds 2MB, upgrading from the official
version of GL-inet (v3.100) using the sysupgrade command will break the
kernel image. Users who are using version 3.100 can only upgrade via
uboot. The official guidance for GL-inet is as follows:
https://docs.gl-inet.com/en/3/troubleshooting/debrick/

In the future, GL-inet will modify the firmware to support the sysupgrade
command, so users will be able to upgrade directly with the sysupgrade
command in future releases.

OLED screen control:
OLED controller is connected to QCA9531 through serial port, and can send
instructions to OLED controller directly through serial port.
Refer to the links below for a list of supported instructions:
https://github.com/gl-inet/GL-E750-MCU-instruction

Signed-off-by: Luochongjun <luochongjun@gl-inet.com>
[fix alphabetic sorting in 10-fix-wifi-mac, drop check-kernel-size]
Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>