### PR TITLE
ath79: add support for Mercury MW4530R v1

### DIFF
--- a/target/linux/ath79/dts/ar9344_mercury_mw4530r-v1.dts
+++ b/target/linux/ath79/dts/ar9344_mercury_mw4530r-v1.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar9344_tplink_tl-wdr4300.dtsi"
+
+/ {
+	model = "Mercury MW4530R v1";
+	compatible = "mercury,mw4530r-v1", "qca,ar9344";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -223,6 +223,19 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "5:wan" "6@eth1" "4:lan"
 		;;
+	mercury,mw4530r-v1|\
+	tplink,archer-a7-v5|\
+	tplink,archer-c6-v2|\
+	tplink,archer-c6-v2-us|\
+	tplink,archer-c7-v4|\
+	tplink,archer-c7-v5|\
+	tplink,tl-wdr3600-v1|\
+	tplink,tl-wdr4300-v1|\
+	tplink,tl-wdr4300-v1-il|\
+	tplink,tl-wdr4310-v1)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "2:lan:1" "3:lan:2" "4:lan:3" "5:lan:4" "1:wan"
+		;;
 	nec,wg1200cr|\
 	ubnt,nanostation-ac|\
 	yuncore,a782|\
@@ -272,18 +285,6 @@ ath79_setup_interfaces()
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:3" "3:lan:2" "4:lan:1"
-		;;
-	tplink,archer-a7-v5|\
-	tplink,archer-c6-v2|\
-	tplink,archer-c6-v2-us|\
-	tplink,archer-c7-v4|\
-	tplink,archer-c7-v5|\
-	tplink,tl-wdr3600-v1|\
-	tplink,tl-wdr4300-v1|\
-	tplink,tl-wdr4300-v1-il|\
-	tplink,tl-wdr4310-v1)
-		ucidef_add_switch "switch0" \
-			"0@eth0" "2:lan:1" "3:lan:2" "4:lan:3" "5:lan:4" "1:wan"
 		;;
 	tplink,archer-c5-v1|\
 	tplink,archer-c7-v1|\
@@ -498,6 +499,13 @@ ath79_setup_macs()
 		wan_mac=$(fconfig -s -r -d $(find_mtd_part "RedBoot config") -n alias/ethaddr)
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		;;
+	mercury,mw4530r-v1|\
+	tplink,tl-wdr3600-v1|\
+	tplink,tl-wdr4300-v1|\
+	tplink,tl-wdr4300-v1-il)
+		base_mac=$(mtd_get_mac_binary u-boot 0x1fc00)
+		wan_mac=$(macaddr_add "$base_mac" 1)
+		;;
 	nec,wg800hp)
 		lan_mac=$(mtd_get_mac_text board_data 0x280)
 		wan_mac=$(mtd_get_mac_text board_data 0x480)
@@ -530,12 +538,6 @@ ath79_setup_macs()
 	tplink,tl-wr1043nd-v4|\
 	tplink,tl-wr1043n-v5)
 		base_mac=$(mtd_get_mac_binary info 0x8)
-		wan_mac=$(macaddr_add "$base_mac" 1)
-		;;
-	tplink,tl-wdr3600-v1|\
-	tplink,tl-wdr4300-v1|\
-	tplink,tl-wdr4300-v1-il)
-		base_mac=$(mtd_get_mac_binary u-boot 0x1fc00)
 		wan_mac=$(macaddr_add "$base_mac" 1)
 		;;
 	trendnet,tew-823dru)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -163,6 +163,7 @@ case "$FIRMWARE" in
 		ath9k_eeprom_extract "calibrate" 0x5000 0x440
 		ath9k_patch_fw_mac $(mtd_get_mac_ascii u-boot-env0 RADIOADDR0) 0x2
 		;;
+	mercury,mw4530r-v1|\
 	ocedo,raccoon|\
 	tplink,tl-wdr3500-v1|\
 	tplink,tl-wdr3600-v1|\

--- a/target/linux/ath79/generic/base-files/etc/uci-defaults/04_led_migration
+++ b/target/linux/ath79/generic/base-files/etc/uci-defaults/04_led_migration
@@ -21,6 +21,14 @@ engenius,epg5000)
 glinet,gl-mifi)
 	migrate_leds ":net=:3g4g"
 	;;
+mercury,mw4530r-v1|\
+tplink,archer-c7-v2|\
+tplink,tl-wdr3600-v1|\
+tplink,tl-wdr4300-v1|\
+tplink,tl-wdr4300-v1-il|\
+tplink,tl-wdr4310-v1)
+	migrate_leds ":blue:=:green:"
+	;;
 tplink,archer-c25-v1|\
 tplink,archer-c58-v1|\
 tplink,archer-c59-v1|\
@@ -31,13 +39,6 @@ tplink,archer-c7-v4|\
 tplink,archer-c7-v5|\
 tplink,tl-wr902ac-v1)
 	migrate_leds "^$boardonly:=tp-link:"
-	;;
-tplink,archer-c7-v2|\
-tplink,tl-wdr3600-v1|\
-tplink,tl-wdr4300-v1|\
-tplink,tl-wdr4300-v1-il|\
-tplink,tl-wdr4310-v1)
-	migrate_leds ":blue:=:green:"
 	;;
 tplink,re355-v1)
 	migrate_leds "re355:=tp-link:"

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1084,6 +1084,18 @@ define Device/meraki_mr16
 endef
 TARGET_DEVICES += meraki_mr16
 
+define Device/mercury_mw4530r-v1
+  $(Device/tplink-8mlzma)
+  SOC := ar9344
+  DEVICE_VENDOR := Mercury
+  DEVICE_MODEL := MW4530R
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport
+  TPLINK_HWID := 0x45300001
+  SUPPORTED_DEVICES += tl-wdr4300
+endef
+TARGET_DEVICES += mercury_mw4530r-v1
+
 define Device/nec_wg1200cr
   SOC := qca9563
   DEVICE_VENDOR := NEC


### PR DESCRIPTION
Mercury MW4530R is a TP-Link TL-WDR4310 clone.

Specification:

* SOC: Atheros AR9344 (560 MHz)
* RAM: 128 MiB
* Flash: 8192 KiB
* Ethernet: 5 x 10/100/1000 (4 x LAN, 1 x WAN) (AR8327)
* Wireless:
  - 2.4 GHz b/g/n (internal)
  - 5 GHz a/n (AR9580)
* USB: yes, 1 x USB 2.0

Installation:

Flash factory image via OEM web interface.

Signed-off-by: Zhong Jianxin <azuwis@gmail.com>