### PR TITLE
omap: update uboot to v2020.04

### DIFF
--- a/package/boot/uboot-omap/Makefile
+++ b/package/boot/uboot-omap/Makefile
@@ -8,10 +8,10 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
-PKG_VERSION:=2019.10
+PKG_VERSION:=2020.04
 PKG_RELEASE:=1
 
-PKG_HASH:=8d6d6070739522dd236cba7055b8736bfe92b4fac0ea18ad809829ca79667014
+PKG_HASH:=fe732aaf037d9cc3c0909bad8362af366ae964bbdac6913a34081ff4ad565372
 
 include $(INCLUDE_DIR)/u-boot.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Fixes the build error:
/usr/bin/ld: scripts/dtc/dtc-parser.tab.o:(.bss+0x10): multiple definition of `yylloc'; scripts/dtc/dtc-lexer.lex.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status

Successfully tested on boneblack.

Signed-off-by: Andre Heider <a.heider@gmail.com>