### PR TITLE
shortcut-fe: rework netfilter conntrack notification

### DIFF
--- a/package/lean/fast-classifier/src/fast-classifier.c
+++ b/package/lean/fast-classifier/src/fast-classifier.c
@@ -1807,10 +1807,12 @@ static int __init fast_classifier_init(void)
 		goto exit3;
 	}
 
-#ifdef CONFIG_NF_CONNTRACK_EVENTS
 	/*
 	 * Register a notifier hook to get fast notifications of expired connections.
 	 */
+#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
+	result = nf_conntrack_register_chain_notifier(&init_net, &fast_classifier_conntrack_notifier);
+#else
 	result = nf_conntrack_register_notifier(&init_net, &fast_classifier_conntrack_notifier);
 	if (result < 0) {
 		DEBUG_ERROR("can't register nf notifier hook: %d\n", result);
@@ -1877,7 +1879,11 @@ exit6:
 
 exit5:
 #ifdef CONFIG_NF_CONNTRACK_EVENTS
+#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
+	nf_conntrack_unregister_chain_notifier(&init_net, &fast_classifier_conntrack_notifier);
+#else
 	nf_conntrack_unregister_notifier(&init_net, &fast_classifier_conntrack_notifier);
+#endif
 
 exit4:
 #endif
@@ -1945,8 +1951,11 @@ static void __exit fast_classifier_exit(void)
 	}
 
 #ifdef CONFIG_NF_CONNTRACK_EVENTS
+#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
+	nf_conntrack_unregister_chain_notifier(&init_net, &fast_classifier_conntrack_notifier);
+#else
 	nf_conntrack_unregister_notifier(&init_net, &fast_classifier_conntrack_notifier);
-
+#endif
 #endif
 	nf_unregister_net_hooks(&init_net, fast_classifier_ops_post_routing, ARRAY_SIZE(fast_classifier_ops_post_routing));
 

--- a/package/lean/shortcut-fe/src/sfe_cm.c
+++ b/package/lean/shortcut-fe/src/sfe_cm.c
@@ -1049,7 +1049,7 @@ static int __init sfe_cm_init(void)
 	 */
 #ifdef CONFIG_NF_CONNTRACK_EVENTS
 #ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
-	(void)nf_conntrack_register_notifier(&init_net, &sfe_cm_conntrack_notifier);
+	(void)nf_conntrack_register_chain_notifier(&init_net, &sfe_cm_conntrack_notifier);
 #else
 	result = nf_conntrack_register_notifier(&init_net, &sfe_cm_conntrack_notifier);
 	if (result < 0) {
@@ -1123,8 +1123,11 @@ static void __exit sfe_cm_exit(void)
 	sfe_ipv6_destroy_all_rules_for_dev(NULL);
 
 #ifdef CONFIG_NF_CONNTRACK_EVENTS
+#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
+	nf_conntrack_unregister_chain_notifier(&init_net, &sfe_cm_conntrack_notifier);
+#else
 	nf_conntrack_unregister_notifier(&init_net, &sfe_cm_conntrack_notifier);
-
+#endif
 #endif
 	nf_unregister_net_hooks(&init_net, sfe_cm_ops_post_routing, ARRAY_SIZE(sfe_cm_ops_post_routing));
 

--- a/target/linux/generic/hack-4.14/953-net-patch-linux-kernel-to-support-shortcut-fe.patch
+++ b/target/linux/generic/hack-4.14/953-net-patch-linux-kernel-to-support-shortcut-fe.patch
@@ -1,6 +1,6 @@
---- a/include/linux/skbuff.h	2019-01-16 20:16:08.325745306 +0800
-+++ b/include/linux/skbuff.h	2019-01-16 20:31:47.288028493 +0800
-@@ -783,6 +783,9 @@ struct sk_buff {
+--- a/include/linux/skbuff.h
++++ b/include/linux/skbuff.h
+@@ -796,6 +796,9 @@ struct sk_buff {
  	__u8			tc_from_ingress:1;
  #endif
  	__u8			gro_skip:1;
@@ -10,8 +10,8 @@
  
  #ifdef CONFIG_NET_SCHED
  	__u16			tc_index;	/* traffic control index */
---- a/include/linux/if_bridge.h	2019-01-16 20:51:47.871445535 +0800
-+++ b/include/linux/if_bridge.h	2019-01-16 20:52:26.220269649 +0800
+--- a/include/linux/if_bridge.h
++++ b/include/linux/if_bridge.h
 @@ -54,6 +54,8 @@ struct br_ip_list {
  #define BR_DEFAULT_AGEING_TIME	(300 * HZ)
  
@@ -33,8 +33,19 @@
  
  #ifdef CONFIG_LOCKDEP
  	struct lockdep_map	lockdep_map;
---- a/net/Kconfig	2019-01-16 20:36:30.266465286 +0800
-+++ b/net/Kconfig	2019-01-16 20:36:41.980609067 +0800
+--- a/include/net/netfilter/nf_conntrack_ecache.h
++++ b/include/net/netfilter/nf_conntrack_ecache.h
+@@ -74,6 +74,8 @@ struct nf_ct_event {
+ #ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
+ extern int nf_conntrack_register_notifier(struct net *net, struct notifier_block *nb);
+ extern int nf_conntrack_unregister_notifier(struct net *net, struct notifier_block *nb);
++extern int nf_conntrack_register_chain_notifier(struct net *net, struct notifier_block *nb);
++extern int nf_conntrack_unregister_chain_notifier(struct net *net, struct notifier_block *nb);
+ #else
+ struct nf_ct_event_notifier {
+ 	int (*fcn)(unsigned int events, struct nf_ct_event *item);
+--- a/net/Kconfig
++++ b/net/Kconfig
 @@ -463,3 +463,6 @@ config HAVE_CBPF_JIT
  # Extended BPF JIT (eBPF)
  config HAVE_EBPF_JIT
@@ -42,19 +53,18 @@
 +
 +config SHORTCUT_FE
 +	bool "Enables kernel network stack path for Shortcut  Forwarding Engine
---- a/net/core/dev.c	2019-01-16 20:38:37.274933833 +0800
-+++ b/net/core/dev.c	2019-01-16 20:44:07.773594898 +0800
-@@ -3005,8 +3005,17 @@ static int xmit_one(struct sk_buff *skb, struct net_device *dev,
- 		!(skb->imq_flags & IMQ_F_ENQUEUE))
+--- a/net/core/dev.c
++++ b/net/core/dev.c
+@@ -3007,7 +3007,16 @@ static int xmit_one(struct sk_buff *skb,
  #else
  	if (!list_empty(&ptype_all) || !list_empty(&dev->ptype_all))
-+#endif
+ #endif
 +#ifdef CONFIG_SHORTCUT_FE
 +	/* If this skb has been fast forwarded then we don't want it to
 +	 * go to any taps (by definition we're trying to bypass them).
 +	 */
 +	if (!skb->fast_forwarded) {
- #endif
++#endif
  		dev_queue_xmit_nit(skb, dev);
 +#ifdef CONFIG_SHORTCUT_FE
 +	}
@@ -62,7 +72,7 @@
  
  #ifdef CONFIG_ETHERNET_PACKET_MANGLE
  	if (!dev->eth_mangle_tx ||
-@@ -4315,6 +4324,11 @@ void netdev_rx_handler_unregister(struct
+@@ -4322,6 +4331,11 @@ void netdev_rx_handler_unregister(struct
  }
  EXPORT_SYMBOL_GPL(netdev_rx_handler_unregister);
  
@@ -74,7 +84,7 @@
  /*
   * Limit the use of PFMEMALLOC reserves to those protocols that implement
   * the special handling of PFMEMALLOC skbs.
-@@ -4362,6 +4376,9 @@ static int __netif_receive_skb_core(stru
+@@ -4369,6 +4383,9 @@ static int __netif_receive_skb_core(stru
  	bool deliver_exact = false;
  	int ret = NET_RX_DROP;
  	__be16 type;
@@ -84,7 +94,7 @@
  
  	net_timestamp_check(!netdev_tstamp_prequeue, skb);
  
-@@ -4388,6 +4405,16 @@ another_round:
+@@ -4395,6 +4412,16 @@ another_round:
  			goto out;
  	}
  
@@ -101,8 +111,8 @@
  	if (skb_skip_tc_classify(skb))
  		goto skip_classify;
  
---- a/net/netfilter/nf_conntrack_proto_tcp.c	2019-01-16 20:47:40.886993297 +0800
-+++ b/net/netfilter/nf_conntrack_proto_tcp.c	2019-01-16 20:48:57.700570104 +0800
+--- a/net/netfilter/nf_conntrack_proto_tcp.c
++++ b/net/netfilter/nf_conntrack_proto_tcp.c
 @@ -35,11 +35,17 @@
  
  /* Do not check the TCP window for incoming packets  */
@@ -121,8 +131,8 @@
  
  /* If it is set to zero, we disable picking up already established
     connections. */
---- a/net/bridge/br_if.c	2019-01-16 20:54:51.919367044 +0800
-+++ b/net/bridge/br_if.c	2019-01-16 20:55:53.812401263 +0800
+--- a/net/bridge/br_if.c
++++ b/net/bridge/br_if.c
 @@ -653,3 +653,26 @@ void br_port_flags_change(struct net_bri
  	if (mask & BR_AUTO_MASK)
  		nbp_update_port_count(br);
@@ -150,77 +160,48 @@
 +	u64_stats_update_end(&stats->syncp);
 +}
 +EXPORT_SYMBOL_GPL(br_dev_update_stats);
---- a/net/netfilter/Kconfig	2019-01-16 21:07:34.543460920 +0800
-+++ b/net/netfilter/Kconfig	2019-01-16 21:08:14.739465937 +0800
-@@ -146,6 +146,14 @@ config NF_CONNTRACK_TIMEOUT
- 
- 	  If unsure, say `N'.
- 
-+config NF_CONNTRACK_CHAIN_EVENTS
-+	bool "Register multiple callbacks to ct events"
-+	depends on NF_CONNTRACK_EVENTS
-+	help
-+	  Support multiple registrations.
-+
-+	  If unsure, say `N'.
-+
- config NF_CONNTRACK_TIMESTAMP
- 	bool  'Connection tracking timestamping'
- 	depends on NETFILTER_ADVANCED
---- a/net/netfilter/nf_conntrack_ecache.c	2019-01-16 21:12:22.183462975 +0800
-+++ b/net/netfilter/nf_conntrack_ecache.c	2019-01-16 21:26:10.379462031 +0800
-@@ -122,13 +125,17 @@ int nf_conntrack_eventmask_report(unsign
- {
- 	int ret = 0;
- 	struct net *net = nf_ct_net(ct);
-+#ifndef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
- 	struct nf_ct_event_notifier *notify;
-+#endif
- 	struct nf_conntrack_ecache *e;
+--- a/net/netfilter/nf_conntrack_ecache.c
++++ b/net/netfilter/nf_conntrack_ecache.c
+@@ -162,7 +162,11 @@ int nf_conntrack_eventmask_report(unsign
  
  	rcu_read_lock();
-+#ifndef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
  	notify = rcu_dereference(net->ct.nf_conntrack_event_cb);
++#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
++	if (!notify && !rcu_dereference_raw(net->ct.nf_conntrack_chain.head))
++#else
  	if (!notify)
- 		goto out_unlock;
 +#endif
+ 		goto out_unlock;
  
  	e = nf_ct_ecache_find(ct);
- 	if (!e)
-@@ -146,7 +153,12 @@ int nf_conntrack_eventmask_report(unsign
+@@ -181,7 +185,14 @@ int nf_conntrack_eventmask_report(unsign
  		if (!((eventmask | missed) & e->ctmask))
  			goto out_unlock;
  
 +#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
 +		ret = atomic_notifier_call_chain(&net->ct.nf_conntrack_chain,
 +			eventmask | missed, &item);
++		if (notify)
++			ret = notify->fcn(eventmask | missed, &item);
 +#else
  		ret = notify->fcn(eventmask | missed, &item);
 +#endif
  		if (unlikely(ret < 0 || missed)) {
  			spin_lock_bh(&ct->lock);
  			if (ret < 0) {
-@@ -179,15 +191,19 @@ void nf_ct_deliver_cached_events(struct
- {
- 	struct net *net = nf_ct_net(ct);
- 	unsigned long events, missed;
-+#ifndef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
- 	struct nf_ct_event_notifier *notify;
-+#endif
- 	struct nf_conntrack_ecache *e;
- 	struct nf_ct_event item;
- 	int ret;
+@@ -263,7 +274,11 @@ void nf_ct_deliver_cached_events(struct
  
  	rcu_read_lock();
-+#ifndef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
  	notify = rcu_dereference(net->ct.nf_conntrack_event_cb);
++#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
++	if ((notify == NULL) && !rcu_dereference_raw(net->ct.nf_conntrack_chain.head))
++#else
  	if (notify == NULL)
- 		goto out_unlock;
 +#endif
+ 		goto out_unlock;
  
  	e = nf_ct_ecache_find(ct);
- 	if (e == NULL)
-@@ -210,7 +226,13 @@ void nf_ct_deliver_cached_events(struct
+@@ -287,7 +302,15 @@ void nf_ct_deliver_cached_events(struct
  	item.portid = 0;
  	item.report = 0;
  
@@ -228,9 +209,35 @@
 +	ret = atomic_notifier_call_chain(&net->ct.nf_conntrack_chain,
 +			events | missed,
 +			&item);
++	if (notify != NULL)
++		ret = notify->fcn(events | missed, &item);
 +#else
  	ret = notify->fcn(events | missed, &item);
 +#endif
  
  	if (likely(ret == 0 && !missed))
  		goto out_unlock;
+@@ -340,6 +363,11 @@ int nf_conntrack_register_notifier(struc
+ {
+         return atomic_notifier_chain_register(&net->ct.nf_conntrack_chain, nb);
+ }
++int nf_conntrack_register_chain_notifier(struct net *net, struct notifier_block *nb)
++{
++	return atomic_notifier_chain_register(&net->ct.nf_conntrack_chain, nb);
++}
++EXPORT_SYMBOL_GPL(nf_conntrack_register_chain_notifier);
+ #else
+ int nf_conntrack_register_notifier(struct net *net,
+ 				   struct nf_ct_event_notifier *new)
+@@ -369,6 +397,11 @@ int nf_conntrack_unregister_notifier(str
+ {
+ 	return atomic_notifier_chain_unregister(&net->ct.nf_conntrack_chain, nb);
+ }
++int nf_conntrack_unregister_chain_notifier(struct net *net, struct notifier_block *nb)
++{
++	return atomic_notifier_chain_unregister(&net->ct.nf_conntrack_chain, nb);
++}
++EXPORT_SYMBOL_GPL(nf_conntrack_unregister_chain_notifier);
+ #else
+ void nf_conntrack_unregister_notifier(struct net *net,
+ 				      struct nf_ct_event_notifier *new)


### PR DESCRIPTION
The original patch from QCA over rode the nf_conntrack_un/register_notifier API, which
will break other modules relying on the API.  Reworked the notification APIs to play nice
with others.