### PR TITLE
oxnas: now longer build KD20 factory image

### DIFF
--- a/target/linux/oxnas/image/ox820.mk
+++ b/target/linux/oxnas/image/ox820.mk
@@ -68,10 +68,6 @@ define Device/shuttle_kd20
   DEVICE_VENDOR := Shuttle
   DEVICE_MODEL := KD20
   SUPPORTED_DEVICES += kd20
-  KERNEL_INITRAMFS_PREFIX = $$(IMAGE_PREFIX)-factory
-  KERNEL_INITRAMFS_SUFFIX := .tar.gz
-  KERNEL_INITRAMFS = kernel-bin | append-dtb | uImage none | omninas-factory | \
-	encrypt-3des sohmuntitnlaes
   DEVICE_PACKAGES := kmod-usb2-oxnas kmod-usb3 kmod-usb-ledtrig-usbport \
 	kmod-i2c-gpio kmod-rtc-pcf8563 kmod-gpio-beeper kmod-hwmon-drivetemp \
 	kmod-hwmon-gpiofan kmod-ata-oxnas-sata kmod-md-mod kmod-md-raid0 \


### PR DESCRIPTION
The image never worked in any release and is also broken in snapshots
due to stock bootloader not loading more than 4 MiB.
Hence it's better to remove the image for now, users who want to flash
OpenWrt on new devices may build LEDE 17.01 with everything possible
disabled to get a small enough and working factory image.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>