### PR TITLE
Revert "base-files: do not generate ULA prefix"

### DIFF
--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -20,6 +20,7 @@ generate_static_network() {
 			uci -q batch <<-EOF
 				delete network.globals
 				set network.globals='globals'
+				set network.globals.ula_prefix='auto'
 			EOF
 		}
 


### PR DESCRIPTION
This reverts commit 9f853eb850dfa4034c3fb333fffc63721bbd81d2.