### PR TITLE
rockchip/sunxi: kernel: adjust default coherent_pool to 2MiB

### DIFF
--- a/target/linux/rockchip/patches-5.4/911-kernel-dma-adjust-default-coherent_pool-to-2MiB.patch
+++ b/target/linux/rockchip/patches-5.4/911-kernel-dma-adjust-default-coherent_pool-to-2MiB.patch
@@ -1,0 +1,20 @@
+From 16bdf3e76fec6ddb44f1fcf221139fb39d225031 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Sat, 2 Jan 2021 05:23:55 +0000
+Subject: [PATCH] kernel: dma: adjust default coherent_pool to 2MiB
+
+---
+ kernel/dma/remap.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/kernel/dma/remap.c
++++ b/kernel/dma/remap.c
+@@ -101,7 +101,7 @@ void dma_common_free_remap(void *cpu_addr, size_t size)
+ #ifdef CONFIG_DMA_DIRECT_REMAP
+ static struct gen_pool *atomic_pool __ro_after_init;
+ 
+-#define DEFAULT_DMA_COHERENT_POOL_SIZE  SZ_256K
++#define DEFAULT_DMA_COHERENT_POOL_SIZE	SZ_2M
+ static size_t atomic_pool_size __initdata = DEFAULT_DMA_COHERENT_POOL_SIZE;
+ 
+ static int __init early_coherent_pool(char *p)

--- a/target/linux/sunxi/patches-5.4/911-kernel-dma-adjust-default-coherent_pool-to-2MiB.patch
+++ b/target/linux/sunxi/patches-5.4/911-kernel-dma-adjust-default-coherent_pool-to-2MiB.patch
@@ -1,0 +1,20 @@
+From 16bdf3e76fec6ddb44f1fcf221139fb39d225031 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Sat, 2 Jan 2021 05:23:55 +0000
+Subject: [PATCH] kernel: dma: adjust default coherent_pool to 2MiB
+
+---
+ kernel/dma/remap.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/kernel/dma/remap.c
++++ b/kernel/dma/remap.c
+@@ -101,7 +101,7 @@ void dma_common_free_remap(void *cpu_addr, size_t size)
+ #ifdef CONFIG_DMA_DIRECT_REMAP
+ static struct gen_pool *atomic_pool __ro_after_init;
+ 
+-#define DEFAULT_DMA_COHERENT_POOL_SIZE  SZ_256K
++#define DEFAULT_DMA_COHERENT_POOL_SIZE	SZ_2M
+ static size_t atomic_pool_size __initdata = DEFAULT_DMA_COHERENT_POOL_SIZE;
+ 
+ static int __init early_coherent_pool(char *p)


### PR DESCRIPTION
Signed-off-by: CN_SZTL <cnsztl@project-openwrt.eu.org>