### PR TITLE
ath79: fix ethernet-phy label for dlink,dap-2660-a1

### DIFF
--- a/target/linux/ath79/dts/qca9557_dlink_dap-2660-a1.dts
+++ b/target/linux/ath79/dts/qca9557_dlink_dap-2660-a1.dts
@@ -63,8 +63,8 @@
 &mdio0 {
 	status = "okay";
 
-	phy0: ethernet-phy@4 {
-		reg = <0x4>;
+	phy4: ethernet-phy@4 {
+		reg = <4>;
 	};
 };
 
@@ -73,7 +73,7 @@
 
 	pll-data = <0x82000000 0x80000101 0x80001313>;
 
-	phy-handle = <&phy0>;
+	phy-handle = <&phy4>;
 	phy-mode = "rgmii-id";
 
 	gmac-config {


### PR DESCRIPTION
The phy label/node name should correspond to the reg property.

While at it, use more common decimal notation for reg property itself.

Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>